### PR TITLE
feat: empty beacon slots, module alt view, hidden recipes & simple entities + variations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
  "flate2",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "prototypes"
-version = "2.0.1-1.1.107"
+version = "2.1.0-1.1.107"
 dependencies = [
  "image 0.25.1",
  "imageproc",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "scanner"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "blueprint",
  "capnpc",
@@ -2896,7 +2896,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "types"
-version = "2.0.1-1.1.107"
+version = "2.1.0-1.1.107"
 dependencies = [
  "image 0.25.1",
  "konst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tokio = "1.36"
 types = { path = "types" }
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "warn"
 
 [workspace.lints.clippy]
 nursery = "warn"

--- a/blueprint/Cargo.toml
+++ b/blueprint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint"
-version = "0.3.0"
+version = "0.4.0"
 authors.workspace = true
 edition.workspace = true
 

--- a/blueprint/src/blueprint.rs
+++ b/blueprint/src/blueprint.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    num::NonZeroU32,
+};
 
 use mod_util::{mod_info::DependencyVersion, AnyBasic, DependencyList};
 use serde::{Deserialize, Serialize};
@@ -157,7 +160,7 @@ impl crate::GetIDs for SignalID {
 }
 
 pub type EntityNumber = u64;
-pub type GraphicsVariation = u8;
+pub type GraphicsVariation = NonZeroU32;
 
 // todo: reduce optionals count by skipping serialization of defaults?
 #[skip_serializing_none]

--- a/prototypes/Cargo.toml
+++ b/prototypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prototypes"
-version = "2.0.1-1.1.107"
+version = "2.1.0-1.1.107"
 authors.workspace = true
 edition.workspace = true
 

--- a/prototypes/src/entity.rs
+++ b/prototypes/src/entity.rs
@@ -258,6 +258,13 @@ pub trait Renderable {
         image_cache: &mut ImageCache,
     ) -> RenderOutput;
 
+    fn fluid_box_connections(&self, options: &RenderOpts) -> Vec<MapPosition> {
+        Vec::with_capacity(0)
+    }
+
+    fn heat_buffer_connections(&self, options: &RenderOpts) -> Vec<MapPosition> {
+        Vec::with_capacity(0)
+    }
 
     fn recipe_visible(&self) -> bool {
         false

--- a/prototypes/src/entity.rs
+++ b/prototypes/src/entity.rs
@@ -258,8 +258,10 @@ pub trait Renderable {
         image_cache: &mut ImageCache,
     ) -> RenderOutput;
 
-    fn fluid_box_connections(&self, options: &RenderOpts) -> Vec<MapPosition>;
-    fn heat_buffer_connections(&self, options: &RenderOpts) -> Vec<MapPosition>;
+
+    fn recipe_visible(&self) -> bool {
+        false
+    }
 }
 
 /// [`Prototypes/EntityPrototype`](https://lua-api.factorio.com/latest/prototypes/EntityPrototype.html)
@@ -293,6 +295,10 @@ impl<T: Renderable> Renderable for EntityPrototype<T> {
     fn heat_buffer_connections(&self, options: &RenderOpts) -> Vec<MapPosition> {
         self.child.heat_buffer_connections(options)
     }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
+    }
 }
 
 pub trait RenderableEntity: Renderable {
@@ -302,6 +308,8 @@ pub trait RenderableEntity: Renderable {
 
     fn pipe_connections(&self, options: &RenderOpts) -> Vec<(MapPosition, Direction)>;
     fn heat_connections(&self, options: &RenderOpts) -> Vec<(MapPosition, Direction)>;
+
+    fn show_recipe(&self) -> bool;
 }
 
 impl<R, T> RenderableEntity for T
@@ -411,6 +419,10 @@ where
                 Some((conn + &options.position, dir))
             })
             .collect()
+    }
+
+    fn show_recipe(&self) -> bool {
+        self.recipe_visible()
     }
 }
 
@@ -549,6 +561,10 @@ impl<T: Renderable> Renderable for EntityData<T> {
 
     fn heat_buffer_connections(&self, options: &RenderOpts) -> Vec<MapPosition> {
         self.child.heat_buffer_connections(options)
+    }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
     }
 }
 
@@ -697,6 +713,10 @@ impl<T: Renderable> Renderable for EntityWithHealthData<T> {
     fn heat_buffer_connections(&self, options: &RenderOpts) -> Vec<MapPosition> {
         self.child.heat_buffer_connections(options)
     }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
+    }
 }
 
 /// [`Prototypes/EntityWithHealthPrototype`](https://lua-api.factorio.com/latest/prototypes/EntityWithHealthPrototype.html)
@@ -741,6 +761,10 @@ impl<T: Renderable> Renderable for EntityWithOwnerData<T> {
 
     fn heat_buffer_connections(&self, options: &RenderOpts) -> Vec<MapPosition> {
         self.child.heat_buffer_connections(options)
+    }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
     }
 }
 

--- a/prototypes/src/entity/abstractions/energy_entity.rs
+++ b/prototypes/src/entity/abstractions/energy_entity.rs
@@ -69,4 +69,8 @@ impl<T: Renderable> Renderable for EnergyEntityData<T> {
 
         child
     }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
+    }
 }

--- a/prototypes/src/entity/abstractions/fluid_box_entity.rs
+++ b/prototypes/src/entity/abstractions/fluid_box_entity.rs
@@ -40,4 +40,8 @@ impl<T: Renderable> Renderable for FluidBoxEntityData<T> {
     fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
         self.child.heat_buffer_connections(options)
     }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
+    }
 }

--- a/prototypes/src/entity/abstractions/heat_buffer_entity.rs
+++ b/prototypes/src/entity/abstractions/heat_buffer_entity.rs
@@ -40,4 +40,8 @@ impl<T: Renderable> Renderable for HeatBufferEntityData<T> {
         res.append(&mut self.child.heat_buffer_connections(options));
         res
     }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
+    }
 }

--- a/prototypes/src/entity/abstractions/wire_entity.rs
+++ b/prototypes/src/entity/abstractions/wire_entity.rs
@@ -72,4 +72,8 @@ impl<T: Renderable> Renderable for WireEntityData<T> {
     fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
         self.child.heat_buffer_connections(options)
     }
+
+    fn recipe_visible(&self) -> bool {
+        self.child.recipe_visible()
+    }
 }

--- a/prototypes/src/entity/accumulator.rs
+++ b/prototypes/src/entity/accumulator.rs
@@ -52,12 +52,4 @@ impl super::Renderable for AccumulatorData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/artillery_turret.rs
+++ b/prototypes/src/entity/artillery_turret.rs
@@ -121,14 +121,6 @@ impl super::Renderable for ArtilleryTurretData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[skip_serializing_none]

--- a/prototypes/src/entity/beacon.rs
+++ b/prototypes/src/entity/beacon.rs
@@ -68,12 +68,4 @@ impl super::Renderable for BeaconData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/boiler.rs
+++ b/prototypes/src/entity/boiler.rs
@@ -60,10 +60,6 @@ impl super::Renderable for BoilerData {
     fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
         self.output_fluid_box.connection_points(options.direction)
     }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/prototypes/src/entity/burner_generator.rs
+++ b/prototypes/src/entity/burner_generator.rs
@@ -58,12 +58,4 @@ impl super::Renderable for BurnerGeneratorData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/combinators.rs
+++ b/prototypes/src/entity/combinators.rs
@@ -143,14 +143,6 @@ impl super::Renderable for ArithmeticCombinatorData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/DeciderCombinatorPrototype`](https://lua-api.factorio.com/latest/prototypes/DeciderCombinatorPrototype.html)
@@ -198,14 +190,6 @@ impl super::Renderable for DeciderCombinatorData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/ConstantCombinatorPrototype`](https://lua-api.factorio.com/latest/prototypes/ConstantCombinatorPrototype.html)
@@ -244,13 +228,5 @@ impl super::Renderable for ConstantCombinatorData {
         render_layers.add_entity(res, &options.position);
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/containers.rs
+++ b/prototypes/src/entity/containers.rs
@@ -56,14 +56,6 @@ impl super::Renderable for ContainerData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -146,14 +138,6 @@ impl super::Renderable for LogisticContainerData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -201,14 +185,6 @@ impl super::Renderable for InfinityContainerData {
         self.parent
             .render(options, used_mods, render_layers, image_cache)
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/LinkedContainerPrototype`](https://lua-api.factorio.com/latest/prototypes/LinkedContainerPrototype.html)
@@ -253,13 +229,5 @@ impl super::Renderable for LinkedContainerData {
         render_layers.add_entity(res, &options.position);
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/crafting_machines.rs
+++ b/prototypes/src/entity/crafting_machines.rs
@@ -177,6 +177,10 @@ impl<T: super::Renderable> super::Renderable for CraftingMachineData<T> {
     fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
         self.child.heat_buffer_connections(options)
     }
+
+    fn recipe_visible(&self) -> bool {
+        self.show_recipe_icon
+    }
 }
 
 // TODO: find a better way to work around this abomination of a type

--- a/prototypes/src/entity/crafting_machines.rs
+++ b/prototypes/src/entity/crafting_machines.rs
@@ -225,14 +225,6 @@ impl super::Renderable for FurnaceData {
     ) -> super::RenderOutput {
         None
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/AssemblingMachinePrototype`](https://lua-api.factorio.com/latest/prototypes/AssemblingMachinePrototype.html)
@@ -266,14 +258,6 @@ impl super::Renderable for AssemblingMachineData {
         image_cache: &mut ImageCache,
     ) -> super::RenderOutput {
         None
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 
@@ -421,13 +405,5 @@ impl super::Renderable for RocketSiloData {
         render_layers.add_entity(res, &options.position);
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/electric_energy_interface.rs
+++ b/prototypes/src/entity/electric_energy_interface.rs
@@ -45,14 +45,6 @@ impl super::Renderable for ElectricEnergyInterfaceData {
             .as_ref()?
             .render(options, used_mods, render_layers, image_cache)
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -102,13 +94,5 @@ impl super::Renderable for ElectricEnergyInterfaceGraphics {
         render_layers.add_entity(res, &options.position);
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/electric_pole.rs
+++ b/prototypes/src/entity/electric_pole.rs
@@ -43,12 +43,4 @@ impl super::Renderable for ElectricPoleData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/flying_robots.rs
+++ b/prototypes/src/entity/flying_robots.rs
@@ -63,14 +63,6 @@ impl<T: super::Renderable> super::Renderable for FlyingRobotData<T> {
     ) -> super::RenderOutput {
         None
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/CombatRobotPrototype`](https://lua-api.factorio.com/latest/prototypes/CombatRobotPrototype.html)
@@ -113,14 +105,6 @@ impl super::Renderable for CombatRobotData {
         image_cache: &mut ImageCache,
     ) -> super::RenderOutput {
         None
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 
@@ -206,14 +190,6 @@ impl super::Renderable for ConstructionRobotData {
     ) -> super::RenderOutput {
         None
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/LogisticRobotPrototype`](https://lua-api.factorio.com/latest/prototypes/LogisticRobotPrototype.html)
@@ -238,13 +214,5 @@ impl super::Renderable for LogisticRobotData {
         image_cache: &mut ImageCache,
     ) -> super::RenderOutput {
         None
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/gate.rs
+++ b/prototypes/src/entity/gate.rs
@@ -94,12 +94,4 @@ impl super::Renderable for GateData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/generator.rs
+++ b/prototypes/src/entity/generator.rs
@@ -77,12 +77,4 @@ impl super::Renderable for GeneratorData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/heat_interface.rs
+++ b/prototypes/src/entity/heat_interface.rs
@@ -37,12 +37,4 @@ impl super::Renderable for HeatInterfaceData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/heat_pipe.rs
+++ b/prototypes/src/entity/heat_pipe.rs
@@ -36,12 +36,4 @@ impl super::Renderable for HeatPipeData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/inserter.rs
+++ b/prototypes/src/entity/inserter.rs
@@ -174,12 +174,4 @@ impl super::Renderable for InserterData {
             Some(())
         }
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/lab.rs
+++ b/prototypes/src/entity/lab.rs
@@ -51,12 +51,4 @@ impl super::Renderable for LabData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/lamp.rs
+++ b/prototypes/src/entity/lamp.rs
@@ -66,14 +66,6 @@ impl super::Renderable for LampData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/prototypes/src/entity/landmine.rs
+++ b/prototypes/src/entity/landmine.rs
@@ -62,12 +62,4 @@ impl super::Renderable for LandMineData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/market.rs
+++ b/prototypes/src/entity/market.rs
@@ -33,12 +33,4 @@ impl super::Renderable for MarketData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/mining_drill.rs
+++ b/prototypes/src/entity/mining_drill.rs
@@ -99,8 +99,4 @@ impl super::Renderable for MiningDrillData {
         input_cons.append(&mut output_cons);
         input_cons
     }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/offshore_pump.rs
+++ b/prototypes/src/entity/offshore_pump.rs
@@ -53,14 +53,6 @@ impl super::Renderable for OffshorePumpData {
         self.graphics
             .render(options, used_mods, render_layers, image_cache)
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[skip_serializing_none]
@@ -100,14 +92,6 @@ impl super::Renderable for OffshorePumpGraphicsVariant {
                 Some(())
             }
         }
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 
@@ -171,13 +155,5 @@ impl super::Renderable for OffshorePumpGraphicsSet {
         render_layers.add_entity(res, &options.position);
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/pipe.rs
+++ b/prototypes/src/entity/pipe.rs
@@ -54,14 +54,6 @@ impl super::Renderable for PipeData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -172,14 +164,6 @@ impl super::Renderable for PipeToGroundData {
         render_layers.add_entity(res, &options.position);
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 

--- a/prototypes/src/entity/power_switch.rs
+++ b/prototypes/src/entity/power_switch.rs
@@ -43,12 +43,4 @@ impl super::Renderable for PowerSwitchData {
 
         // TODO: render open / closed depending on render option flag
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/programmable_speaker.rs
+++ b/prototypes/src/entity/programmable_speaker.rs
@@ -46,14 +46,6 @@ impl super::Renderable for ProgrammableSpeakerData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/prototypes/src/entity/pump.rs
+++ b/prototypes/src/entity/pump.rs
@@ -62,14 +62,6 @@ impl super::Renderable for PumpData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/prototypes/src/entity/radar.rs
+++ b/prototypes/src/entity/radar.rs
@@ -53,12 +53,4 @@ impl super::Renderable for RadarData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/rail_signals.rs
+++ b/prototypes/src/entity/rail_signals.rs
@@ -79,14 +79,6 @@ impl super::Renderable for RailSignalBaseData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/RailChainSignalPrototype`](https://lua-api.factorio.com/latest/prototypes/RailChainSignalPrototype.html)
@@ -159,14 +151,6 @@ impl super::Renderable for RailChainSignalData {
             image_cache,
         )
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/RailSignalPrototype`](https://lua-api.factorio.com/latest/prototypes/RailSignalPrototype.html)
@@ -206,13 +190,5 @@ impl super::Renderable for RailSignalData {
 
         self.parent
             .render(options, used_mods, render_layers, image_cache)
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/rails.rs
+++ b/prototypes/src/entity/rails.rs
@@ -132,14 +132,6 @@ impl<T: RailDirectionPrototype> super::Renderable for RailData<T> {
             }
         }
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/CurvedRailPrototype`](https://lua-api.factorio.com/latest/prototypes/CurvedRailPrototype.html)
@@ -311,13 +303,5 @@ impl super::Renderable for RailPieceLayers {
         } else {
             Some(())
         }
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/reactor.rs
+++ b/prototypes/src/entity/reactor.rs
@@ -79,12 +79,4 @@ impl super::Renderable for ReactorData {
 
         // TODO: include heatpipes (and maybe glow?)
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/roboport.rs
+++ b/prototypes/src/entity/roboport.rs
@@ -143,12 +143,4 @@ impl super::Renderable for RoboportData {
 
         // TODO: include base_animation & doors
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/simple_entities.rs
+++ b/prototypes/src/entity/simple_entities.rs
@@ -46,14 +46,6 @@ impl super::Renderable for SimpleEntityData {
     ) -> super::RenderOutput {
         None
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -128,14 +120,6 @@ impl super::Renderable for SimpleEntityWithOwnerData {
 
         render_layers.add_entity(res, &options.position);
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 

--- a/prototypes/src/entity/simple_entities.rs
+++ b/prototypes/src/entity/simple_entities.rs
@@ -105,7 +105,29 @@ impl super::Renderable for SimpleEntityWithOwnerData {
         render_layers: &mut crate::RenderLayerBuffer,
         image_cache: &mut ImageCache,
     ) -> super::RenderOutput {
-        None
+        let res = match self.graphics.as_ref()? {
+            SimpleEntityGraphics::Pictures { pictures } => pictures.render(
+                render_layers.scale(),
+                used_mods,
+                image_cache,
+                &options.into(),
+            ),
+            SimpleEntityGraphics::Picture { picture } => picture.render(
+                render_layers.scale(),
+                used_mods,
+                image_cache,
+                &options.into(),
+            ),
+            SimpleEntityGraphics::Animations { animations } => animations.render(
+                render_layers.scale(),
+                used_mods,
+                image_cache,
+                &options.into(),
+            ),
+        }?;
+
+        render_layers.add_entity(res, &options.position);
+        Some(())
     }
 
     fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {

--- a/prototypes/src/entity/solar_panel.rs
+++ b/prototypes/src/entity/solar_panel.rs
@@ -37,12 +37,4 @@ impl super::Renderable for SolarPanelData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }

--- a/prototypes/src/entity/storage_tank.rs
+++ b/prototypes/src/entity/storage_tank.rs
@@ -80,14 +80,6 @@ impl super::Renderable for StorageTankData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/prototypes/src/entity/train_stop.rs
+++ b/prototypes/src/entity/train_stop.rs
@@ -110,14 +110,6 @@ impl super::Renderable for TrainStopData {
             Some(())
         }
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -158,13 +150,5 @@ impl super::Renderable for TrainStopLight {
         );
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/transport_belts.rs
+++ b/prototypes/src/entity/transport_belts.rs
@@ -107,14 +107,6 @@ impl super::Renderable for BeltGraphics {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/LinkedBeltPrototype`](https://lua-api.factorio.com/latest/prototypes/LinkedBeltPrototype.html)
@@ -605,14 +597,6 @@ impl super::Renderable for BeltGraphicsWithCorners {
         render_layers.add_entity(res, &options.position);
 
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 

--- a/prototypes/src/entity/turrets.rs
+++ b/prototypes/src/entity/turrets.rs
@@ -169,14 +169,6 @@ impl super::Renderable for TurretData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/AmmoTurretPrototype`](https://lua-api.factorio.com/latest/prototypes/AmmoTurretPrototype.html)

--- a/prototypes/src/entity/vehicles.rs
+++ b/prototypes/src/entity/vehicles.rs
@@ -172,14 +172,6 @@ impl super::Renderable for CarData {
     ) -> super::RenderOutput {
         None
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -463,14 +455,6 @@ impl super::Renderable for ArtilleryWagonData {
             Some(())
         }
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 /// [`Prototypes/CargoWagonPrototype`](https://lua-api.factorio.com/latest/prototypes/CargoWagonPrototype.html)
@@ -492,14 +476,6 @@ impl super::Renderable for CargoWagonData {
         image_cache: &mut ImageCache,
     ) -> super::RenderOutput {
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 
@@ -524,14 +500,6 @@ impl super::Renderable for FluidWagonData {
         image_cache: &mut ImageCache,
     ) -> super::RenderOutput {
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }
 
@@ -578,13 +546,5 @@ impl super::Renderable for LocomotiveData {
         image_cache: &mut ImageCache,
     ) -> super::RenderOutput {
         Some(())
-    }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
     }
 }

--- a/prototypes/src/entity/wall.rs
+++ b/prototypes/src/entity/wall.rs
@@ -132,14 +132,6 @@ impl super::Renderable for WallData {
 
         Some(())
     }
-
-    fn fluid_box_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
-
-    fn heat_buffer_connections(&self, options: &super::RenderOpts) -> Vec<types::MapPosition> {
-        Vec::with_capacity(0)
-    }
 }
 
 #[skip_serializing_none]

--- a/scanner/Cargo.toml
+++ b/scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scanner"
-version = "0.4.0"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 

--- a/scanner/src/lib.rs
+++ b/scanner/src/lib.rs
@@ -287,6 +287,7 @@ pub fn bp_entity2render_opts(
         position: (&value.position).into(),
         direction: value.direction,
         orientation: value.orientation,
+        variation: value.variation,
         pickup_position: value
             .pickup_position
             .as_ref()

--- a/scanner/src/lib.rs
+++ b/scanner/src/lib.rs
@@ -518,10 +518,10 @@ pub fn render_bp(
         .entities
         .iter()
         .filter_map(|e| {
-            if !data.contains_entity(&e.name) {
+            let Some(e_data) = data.get_entity(&e.name) else {
                 unknown.insert(e.name.clone());
                 return None;
-            }
+            };
 
             let mut connected_gates: Vec<Direction> = Vec::new();
             let mut draw_gate_patch = false;
@@ -660,7 +660,7 @@ pub fn render_bp(
             render_opts.draw_gate_patch = draw_gate_patch;
 
             'recipe_icon: {
-                if !e.recipe.is_empty() {
+                if !e.recipe.is_empty() && e_data.recipe_visible() {
                     if !data.contains_recipe(&e.recipe) {
                         unknown.insert(e.recipe.clone());
                         break 'recipe_icon;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "types"
-version = "2.0.1-1.1.107"
+version = "2.1.0-1.1.107"
 authors.workspace = true
 edition.workspace = true
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1647,6 +1647,44 @@ impl BoundingBox {
     pub const fn bottom_right(&self) -> &MapPosition {
         &self.1
     }
+
+    #[must_use]
+    pub const fn top(&self) -> f64 {
+        self.0.y()
+    }
+
+    #[must_use]
+    pub const fn bottom(&self) -> f64 {
+        self.1.y()
+    }
+
+    #[must_use]
+    pub const fn left(&self) -> f64 {
+        self.0.x()
+    }
+
+    #[must_use]
+    pub const fn right(&self) -> f64 {
+        self.1.x()
+    }
+
+    #[must_use]
+    pub fn width(&self) -> f64 {
+        self.right() - self.left()
+    }
+
+    #[must_use]
+    pub fn height(&self) -> f64 {
+        self.bottom() - self.top()
+    }
+
+    #[must_use]
+    pub fn center(&self) -> MapPosition {
+        let (x1, y1) = self.0.as_tuple();
+        let (x2, y2) = self.1.as_tuple();
+
+        MapPosition::Tuple((x1 + x2) / 2.0, (y1 + y2) / 2.0)
+    }
 }
 
 /// [`Types/Direction`](https://lua-api.factorio.com/latest/types/Direction.html)

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -1979,10 +1979,7 @@ impl RenderableGraphics for BeaconModuleVisualizations {
                                         scale,
                                         used_mods,
                                         image_cache,
-                                        &SpriteVariationsRenderOpts {
-                                            variation: 0,
-                                            runtime_tint: None,
-                                        },
+                                        &SpriteVariationsRenderOpts::default(),
                                     )
                                 })
                             } else {


### PR DESCRIPTION
- rendering empty beacon module slots
- hide recipe icons on entities that have `show_recipe_icon` set to `false`
- show modules / item requests
- rendering of simple entities + sprite variations (pyanodons vessel pipes)