### PR TITLE
fix: respect walls `visual_merge_group`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,7 +1918,7 @@ dependencies = [
 
 [[package]]
 name = "prototypes"
-version = "2.1.0-1.1.107"
+version = "2.2.0-1.1.107"
 dependencies = [
  "image 0.25.1",
  "imageproc",
@@ -2928,7 +2928,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "types"
-version = "2.1.0-1.1.107"
+version = "2.2.0-1.1.107"
 dependencies = [
  "image 0.25.1",
  "konst",

--- a/prototypes/Cargo.toml
+++ b/prototypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prototypes"
-version = "2.1.0-1.1.107"
+version = "2.2.0-1.1.107"
 authors.workspace = true
 edition.workspace = true
 

--- a/prototypes/src/entity.rs
+++ b/prototypes/src/entity.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, num::NonZeroU32, ops::Deref};
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroU32,
+    ops::Deref,
+};
 
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -903,7 +907,7 @@ impl Type {
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct EntityPrototypeMap<T: Renderable>(HashMap<String, T>);
+pub struct EntityPrototypeMap<T: Renderable>(HashMap<EntityID, T>);
 
 impl<T> Default for EntityPrototypeMap<T>
 where
@@ -915,7 +919,7 @@ where
 }
 
 impl<T: Renderable> Deref for EntityPrototypeMap<T> {
-    type Target = HashMap<String, T>;
+    type Target = HashMap<EntityID, T>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -1019,4 +1023,546 @@ pub struct AllTypes {
     // pub player_port: EntityPrototypeMap<PlayerPortPrototype>,
     // pub unit: EntityPrototypeMap<UnitPrototype>,
     // pub spider_vehicle: EntityPrototypeMap<SpiderVehiclePrototype>,
+}
+
+impl crate::IdNamespace for AllTypes {
+    type Id = EntityID;
+
+    fn all_ids(&self) -> std::collections::HashSet<&Self::Id> {
+        let mut res = HashSet::new();
+
+        res.extend(self.accumulator.keys());
+        res.extend(self.artillery_turret.keys());
+        res.extend(self.beacon.keys());
+        res.extend(self.boiler.keys());
+        res.extend(self.burner_generator.keys());
+        res.extend(self.arithmetic_combinator.keys());
+        res.extend(self.decider_combinator.keys());
+        res.extend(self.constant_combinator.keys());
+        res.extend(self.programmable_speaker.keys());
+        res.extend(self.container.keys());
+        res.extend(self.logistic_container.keys());
+        res.extend(self.infinity_container.keys());
+        res.extend(self.linked_container.keys());
+        res.extend(self.assembling_machine.keys());
+        res.extend(self.rocket_silo.keys());
+        res.extend(self.furnace.keys());
+        res.extend(self.electric_energy_interface.keys());
+        res.extend(self.electric_pole.keys());
+        res.extend(self.power_switch.keys());
+        res.extend(self.combat_robot.keys());
+        res.extend(self.construction_robot.keys());
+        res.extend(self.logistic_robot.keys());
+        res.extend(self.roboport.keys());
+        res.extend(self.gate.keys());
+        res.extend(self.wall.keys());
+        res.extend(self.generator.keys());
+        res.extend(self.reactor.keys());
+        res.extend(self.heat_interface.keys());
+        res.extend(self.heat_pipe.keys());
+        res.extend(self.inserter.keys());
+        res.extend(self.lab.keys());
+        res.extend(self.lamp.keys());
+        res.extend(self.land_mine.keys());
+        res.extend(self.market.keys());
+        res.extend(self.mining_drill.keys());
+        res.extend(self.offshore_pump.keys());
+        res.extend(self.pipe.keys());
+        res.extend(self.infinity_pipe.keys());
+        res.extend(self.pipe_to_ground.keys());
+        res.extend(self.pump.keys());
+        res.extend(self.simple_entity.keys());
+        res.extend(self.simple_entity_with_owner.keys());
+        res.extend(self.simple_entity_with_force.keys());
+        res.extend(self.solar_panel.keys());
+        res.extend(self.storage_tank.keys());
+        res.extend(self.linked_belt.keys());
+        res.extend(self.loader_1x1.keys());
+        res.extend(self.loader.keys());
+        res.extend(self.splitter.keys());
+        res.extend(self.transport_belt.keys());
+        res.extend(self.underground_belt.keys());
+        res.extend(self.radar.keys());
+        res.extend(self.turret.keys());
+        res.extend(self.ammo_turret.keys());
+        res.extend(self.electric_turret.keys());
+        res.extend(self.fluid_turret.keys());
+        res.extend(self.car.keys());
+        res.extend(self.curved_rail.keys());
+        res.extend(self.straight_rail.keys());
+        res.extend(self.rail_signal.keys());
+        res.extend(self.rail_chain_signal.keys());
+        res.extend(self.train_stop.keys());
+        res.extend(self.locomotive.keys());
+        res.extend(self.cargo_wagon.keys());
+        res.extend(self.fluid_wagon.keys());
+        res.extend(self.artillery_wagon.keys());
+
+        res
+    }
+
+    fn contains(&self, id: &Self::Id) -> bool {
+        self.accumulator.contains_key(id)
+            || self.artillery_turret.contains_key(id)
+            || self.beacon.contains_key(id)
+            || self.boiler.contains_key(id)
+            || self.burner_generator.contains_key(id)
+            || self.arithmetic_combinator.contains_key(id)
+            || self.decider_combinator.contains_key(id)
+            || self.constant_combinator.contains_key(id)
+            || self.programmable_speaker.contains_key(id)
+            || self.container.contains_key(id)
+            || self.logistic_container.contains_key(id)
+            || self.infinity_container.contains_key(id)
+            || self.linked_container.contains_key(id)
+            || self.assembling_machine.contains_key(id)
+            || self.rocket_silo.contains_key(id)
+            || self.furnace.contains_key(id)
+            || self.electric_energy_interface.contains_key(id)
+            || self.electric_pole.contains_key(id)
+            || self.power_switch.contains_key(id)
+            || self.combat_robot.contains_key(id)
+            || self.construction_robot.contains_key(id)
+            || self.logistic_robot.contains_key(id)
+            || self.roboport.contains_key(id)
+            || self.gate.contains_key(id)
+            || self.wall.contains_key(id)
+            || self.generator.contains_key(id)
+            || self.reactor.contains_key(id)
+            || self.heat_interface.contains_key(id)
+            || self.heat_pipe.contains_key(id)
+            || self.inserter.contains_key(id)
+            || self.lab.contains_key(id)
+            || self.lamp.contains_key(id)
+            || self.land_mine.contains_key(id)
+            || self.market.contains_key(id)
+            || self.mining_drill.contains_key(id)
+            || self.offshore_pump.contains_key(id)
+            || self.pipe.contains_key(id)
+            || self.infinity_pipe.contains_key(id)
+            || self.pipe_to_ground.contains_key(id)
+            || self.pump.contains_key(id)
+            || self.simple_entity.contains_key(id)
+            || self.simple_entity_with_owner.contains_key(id)
+            || self.simple_entity_with_force.contains_key(id)
+            || self.solar_panel.contains_key(id)
+            || self.storage_tank.contains_key(id)
+            || self.linked_belt.contains_key(id)
+            || self.loader_1x1.contains_key(id)
+            || self.loader.contains_key(id)
+            || self.splitter.contains_key(id)
+            || self.transport_belt.contains_key(id)
+            || self.underground_belt.contains_key(id)
+            || self.radar.contains_key(id)
+            || self.turret.contains_key(id)
+            || self.ammo_turret.contains_key(id)
+            || self.electric_turret.contains_key(id)
+            || self.fluid_turret.contains_key(id)
+            || self.car.contains_key(id)
+            || self.curved_rail.contains_key(id)
+            || self.straight_rail.contains_key(id)
+            || self.rail_signal.contains_key(id)
+            || self.rail_chain_signal.contains_key(id)
+            || self.train_stop.contains_key(id)
+            || self.locomotive.contains_key(id)
+            || self.cargo_wagon.contains_key(id)
+            || self.fluid_wagon.contains_key(id)
+            || self.artillery_wagon.contains_key(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<AccumulatorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&AccumulatorPrototype> {
+        self.accumulator.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ArtilleryTurretPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ArtilleryTurretPrototype> {
+        self.artillery_turret.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<BeaconPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&BeaconPrototype> {
+        self.beacon.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<BoilerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&BoilerPrototype> {
+        self.boiler.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<BurnerGeneratorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&BurnerGeneratorPrototype> {
+        self.burner_generator.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ArithmeticCombinatorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ArithmeticCombinatorPrototype> {
+        self.arithmetic_combinator.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<DeciderCombinatorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&DeciderCombinatorPrototype> {
+        self.decider_combinator.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ConstantCombinatorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ConstantCombinatorPrototype> {
+        self.constant_combinator.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ProgrammableSpeakerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ProgrammableSpeakerPrototype> {
+        self.programmable_speaker.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ContainerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ContainerPrototype> {
+        self.container.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LogisticContainerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LogisticContainerPrototype> {
+        self.logistic_container.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<InfinityContainerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&InfinityContainerPrototype> {
+        self.infinity_container.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LinkedContainerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LinkedContainerPrototype> {
+        self.linked_container.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<AssemblingMachinePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&AssemblingMachinePrototype> {
+        self.assembling_machine.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<RocketSiloPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&RocketSiloPrototype> {
+        self.rocket_silo.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<FurnacePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&FurnacePrototype> {
+        self.furnace.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ElectricEnergyInterfacePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ElectricEnergyInterfacePrototype> {
+        self.electric_energy_interface.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ElectricPolePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ElectricPolePrototype> {
+        self.electric_pole.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<PowerSwitchPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&PowerSwitchPrototype> {
+        self.power_switch.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<CombatRobotPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&CombatRobotPrototype> {
+        self.combat_robot.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ConstructionRobotPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ConstructionRobotPrototype> {
+        self.construction_robot.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LogisticRobotPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LogisticRobotPrototype> {
+        self.logistic_robot.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<RoboportPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&RoboportPrototype> {
+        self.roboport.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<GatePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&GatePrototype> {
+        self.gate.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<WallPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&WallPrototype> {
+        self.wall.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<GeneratorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&GeneratorPrototype> {
+        self.generator.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ReactorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ReactorPrototype> {
+        self.reactor.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<HeatInterfacePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&HeatInterfacePrototype> {
+        self.heat_interface.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<HeatPipePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&HeatPipePrototype> {
+        self.heat_pipe.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<InserterPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&InserterPrototype> {
+        self.inserter.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LabPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LabPrototype> {
+        self.lab.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LampPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LampPrototype> {
+        self.lamp.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LandMinePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LandMinePrototype> {
+        self.land_mine.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<MarketPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&MarketPrototype> {
+        self.market.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<MiningDrillPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&MiningDrillPrototype> {
+        self.mining_drill.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<OffshorePumpPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&OffshorePumpPrototype> {
+        self.offshore_pump.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<PipePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&PipePrototype> {
+        self.pipe.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<InfinityPipePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&InfinityPipePrototype> {
+        self.infinity_pipe.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<PipeToGroundPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&PipeToGroundPrototype> {
+        self.pipe_to_ground.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<PumpPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&PumpPrototype> {
+        self.pump.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<SimpleEntityPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&SimpleEntityPrototype> {
+        self.simple_entity.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<SimpleEntityWithOwnerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&SimpleEntityWithOwnerPrototype> {
+        self.simple_entity_with_owner.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<SimpleEntityWithForcePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&SimpleEntityWithForcePrototype> {
+        self.simple_entity_with_force.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<SolarPanelPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&SolarPanelPrototype> {
+        self.solar_panel.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<StorageTankPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&StorageTankPrototype> {
+        self.storage_tank.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LinkedBeltPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LinkedBeltPrototype> {
+        self.linked_belt.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<Loader1x1Prototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&Loader1x1Prototype> {
+        self.loader_1x1.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<Loader1x2Prototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&Loader1x2Prototype> {
+        self.loader.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<SplitterPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&SplitterPrototype> {
+        self.splitter.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<TransportBeltPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&TransportBeltPrototype> {
+        self.transport_belt.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<UndergroundBeltPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&UndergroundBeltPrototype> {
+        self.underground_belt.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<RadarPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&RadarPrototype> {
+        self.radar.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<TurretPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&TurretPrototype> {
+        self.turret.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<AmmoTurretPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&AmmoTurretPrototype> {
+        self.ammo_turret.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ElectricTurretPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ElectricTurretPrototype> {
+        self.electric_turret.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<FluidTurretPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&FluidTurretPrototype> {
+        self.fluid_turret.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<CarPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&CarPrototype> {
+        self.car.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<CurvedRailPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&CurvedRailPrototype> {
+        self.curved_rail.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<StraightRailPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&StraightRailPrototype> {
+        self.straight_rail.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<RailSignalPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&RailSignalPrototype> {
+        self.rail_signal.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<RailChainSignalPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&RailChainSignalPrototype> {
+        self.rail_chain_signal.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<TrainStopPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&TrainStopPrototype> {
+        self.train_stop.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<LocomotivePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&LocomotivePrototype> {
+        self.locomotive.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<CargoWagonPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&CargoWagonPrototype> {
+        self.cargo_wagon.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<FluidWagonPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&FluidWagonPrototype> {
+        self.fluid_wagon.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ArtilleryWagonPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ArtilleryWagonPrototype> {
+        self.artillery_wagon.get(id)
+    }
 }

--- a/prototypes/src/entity/simple_entities.rs
+++ b/prototypes/src/entity/simple_entities.rs
@@ -126,4 +126,28 @@ impl super::Renderable for SimpleEntityWithOwnerData {
 /// [`Prototypes/SimpleEntityWithForcePrototype`](https://lua-api.factorio.com/latest/prototypes/SimpleEntityWithForcePrototype.html)
 ///
 /// The only difference to `SimpleEntityWithOwnerPrototype` is that `is_military_target` defaults to `true` which is not relevant -> difference is not implemented.
-pub type SimpleEntityWithForcePrototype = SimpleEntityWithOwnerPrototype;
+pub type SimpleEntityWithForcePrototype = EntityWithOwnerPrototype<SimpleEntityWithForceData>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SimpleEntityWithForceData(SimpleEntityWithOwnerData);
+
+impl std::ops::Deref for SimpleEntityWithForceData {
+    type Target = SimpleEntityWithOwnerData;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl super::Renderable for SimpleEntityWithForceData {
+    fn render(
+        &self,
+        options: &super::RenderOpts,
+        used_mods: &UsedMods,
+        render_layers: &mut crate::RenderLayerBuffer,
+        image_cache: &mut ImageCache,
+    ) -> super::RenderOutput {
+        self.0
+            .render(options, used_mods, render_layers, image_cache)
+    }
+}

--- a/prototypes/src/item.rs
+++ b/prototypes/src/item.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -9,8 +9,6 @@ use types::{
     IconData, ItemCountType, ItemID, ItemProductPrototype, ItemPrototypeFlags, RenderableGraphics,
     SpriteVariations, TileID,
 };
-
-use crate::PrototypeMap;
 
 mod ammo;
 mod capsule;
@@ -132,44 +130,47 @@ pub enum RocketLaunchProduct {
     Single(ItemProductPrototype),
 }
 
+type ItemPrototypeMap<T> = HashMap<ItemID, T>;
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct AllTypes {
-    pub item: PrototypeMap<ItemPrototype>,
+    pub item: ItemPrototypeMap<ItemPrototype>,
 
-    pub ammo: PrototypeMap<AmmoItemPrototype>,
+    pub ammo: ItemPrototypeMap<AmmoItemPrototype>,
 
-    pub capsule: PrototypeMap<CapsulePrototype>,
+    pub capsule: ItemPrototypeMap<CapsulePrototype>,
 
-    pub gun: PrototypeMap<GunPrototype>,
+    pub gun: ItemPrototypeMap<GunPrototype>,
 
-    pub item_with_entity_data: PrototypeMap<ItemWithEntityDataPrototype>,
+    pub item_with_entity_data: ItemPrototypeMap<ItemWithEntityDataPrototype>,
 
-    pub item_with_label: PrototypeMap<ItemWithLabelPrototype>,
-    pub item_with_inventory: PrototypeMap<ItemWithInventoryPrototype>,
-    pub blueprint_book: PrototypeMap<BlueprintBookPrototype>,
-    pub item_with_tags: PrototypeMap<ItemWithTagsPrototype>,
-    pub selection_tool: PrototypeMap<SelectionToolPrototype>,
-    pub blueprint: PrototypeMap<BlueprintItemPrototype>,
-    pub copy_paste_tool: PrototypeMap<CopyPasteToolPrototype>,
-    pub deconstruction_item: PrototypeMap<DeconstructionItemPrototype>,
-    pub upgrade_item: PrototypeMap<UpgradeItemPrototype>,
+    pub item_with_label: ItemPrototypeMap<ItemWithLabelPrototype>,
+    pub item_with_inventory: ItemPrototypeMap<ItemWithInventoryPrototype>,
+    pub blueprint_book: ItemPrototypeMap<BlueprintBookPrototype>,
+    pub item_with_tags: ItemPrototypeMap<ItemWithTagsPrototype>,
+    pub selection_tool: ItemPrototypeMap<SelectionToolPrototype>,
+    pub blueprint: ItemPrototypeMap<BlueprintItemPrototype>,
+    pub copy_paste_tool: ItemPrototypeMap<CopyPasteToolPrototype>,
+    pub deconstruction_item: ItemPrototypeMap<DeconstructionItemPrototype>,
+    pub upgrade_item: ItemPrototypeMap<UpgradeItemPrototype>,
 
-    pub module: PrototypeMap<ModulePrototype>,
+    pub module: ItemPrototypeMap<ModulePrototype>,
 
-    pub rail_planner: PrototypeMap<RailPlannerPrototype>,
+    pub rail_planner: ItemPrototypeMap<RailPlannerPrototype>,
 
-    pub spidertron_remote: PrototypeMap<SpidertronRemotePrototype>,
+    pub spidertron_remote: ItemPrototypeMap<SpidertronRemotePrototype>,
 
-    pub tool: PrototypeMap<ToolPrototype>,
-    pub armor: PrototypeMap<ArmorPrototype>,
-    pub mining_tool: PrototypeMap<MiningToolPrototype>,
-    pub repair_tool: PrototypeMap<RepairToolPrototype>,
+    pub tool: ItemPrototypeMap<ToolPrototype>,
+    pub armor: ItemPrototypeMap<ArmorPrototype>,
+    pub mining_tool: ItemPrototypeMap<MiningToolPrototype>,
+    pub repair_tool: ItemPrototypeMap<RepairToolPrototype>,
 }
 
-impl AllTypes {
-    #[must_use]
-    pub fn all_names(&self) -> HashSet<&ItemID> {
+impl crate::IdNamespace for AllTypes {
+    type Id = ItemID;
+
+    fn all_ids(&self) -> HashSet<&Self::Id> {
         let mut res = HashSet::new();
 
         res.extend(self.item.keys());
@@ -197,6 +198,158 @@ impl AllTypes {
         res
     }
 
+    fn contains(&self, id: &Self::Id) -> bool {
+        self.item.contains_key(id)
+            || self.ammo.contains_key(id)
+            || self.capsule.contains_key(id)
+            || self.gun.contains_key(id)
+            || self.item_with_entity_data.contains_key(id)
+            || self.item_with_label.contains_key(id)
+            || self.item_with_inventory.contains_key(id)
+            || self.blueprint_book.contains_key(id)
+            || self.item_with_tags.contains_key(id)
+            || self.selection_tool.contains_key(id)
+            || self.blueprint.contains_key(id)
+            || self.copy_paste_tool.contains_key(id)
+            || self.deconstruction_item.contains_key(id)
+            || self.upgrade_item.contains_key(id)
+            || self.module.contains_key(id)
+            || self.rail_planner.contains_key(id)
+            || self.spidertron_remote.contains_key(id)
+            || self.tool.contains_key(id)
+            || self.armor.contains_key(id)
+            || self.mining_tool.contains_key(id)
+            || self.repair_tool.contains_key(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ItemPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ItemPrototype> {
+        self.item.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<AmmoItemPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&AmmoItemPrototype> {
+        self.ammo.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<CapsulePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&CapsulePrototype> {
+        self.capsule.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<GunPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&GunPrototype> {
+        self.gun.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ItemWithEntityDataPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ItemWithEntityDataPrototype> {
+        self.item_with_entity_data.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ItemWithLabelPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ItemWithLabelPrototype> {
+        self.item_with_label.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ItemWithInventoryPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ItemWithInventoryPrototype> {
+        self.item_with_inventory.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<BlueprintBookPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&BlueprintBookPrototype> {
+        self.blueprint_book.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ItemWithTagsPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ItemWithTagsPrototype> {
+        self.item_with_tags.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<SelectionToolPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&SelectionToolPrototype> {
+        self.selection_tool.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<BlueprintItemPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&BlueprintItemPrototype> {
+        self.blueprint.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<CopyPasteToolPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&CopyPasteToolPrototype> {
+        self.copy_paste_tool.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<DeconstructionItemPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&DeconstructionItemPrototype> {
+        self.deconstruction_item.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<UpgradeItemPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&UpgradeItemPrototype> {
+        self.upgrade_item.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ModulePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ModulePrototype> {
+        self.module.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<RailPlannerPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&RailPlannerPrototype> {
+        self.rail_planner.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<SpidertronRemotePrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&SpidertronRemotePrototype> {
+        self.spidertron_remote.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ToolPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ToolPrototype> {
+        self.tool.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<ArmorPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&ArmorPrototype> {
+        self.armor.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<MiningToolPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&MiningToolPrototype> {
+        self.mining_tool.get(id)
+    }
+}
+
+impl crate::IdNamespaceAccess<RepairToolPrototype> for AllTypes {
+    fn get_proto(&self, id: &Self::Id) -> Option<&RepairToolPrototype> {
+        self.repair_tool.get(id)
+    }
+}
+
+impl AllTypes {
     pub fn get_icon(
         &self,
         name: &str,
@@ -204,88 +357,90 @@ impl AllTypes {
         used_mods: &mod_util::UsedMods,
         image_cache: &mut types::ImageCache,
     ) -> Option<types::GraphicsOutput> {
-        if self.item.contains_key(name) {
-            return self.item[name].get_icon(scale, used_mods, image_cache);
+        let id = &ItemID::new(name);
+
+        if self.item.contains_key(id) {
+            return self.item[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.ammo.contains_key(name) {
-            return self.ammo[name].get_icon(scale, used_mods, image_cache);
+        if self.ammo.contains_key(id) {
+            return self.ammo[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.capsule.contains_key(name) {
-            return self.capsule[name].get_icon(scale, used_mods, image_cache);
+        if self.capsule.contains_key(id) {
+            return self.capsule[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.gun.contains_key(name) {
-            return self.gun[name].get_icon(scale, used_mods, image_cache);
+        if self.gun.contains_key(id) {
+            return self.gun[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.item_with_entity_data.contains_key(name) {
-            return self.item_with_entity_data[name].get_icon(scale, used_mods, image_cache);
+        if self.item_with_entity_data.contains_key(id) {
+            return self.item_with_entity_data[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.item_with_label.contains_key(name) {
-            return self.item_with_label[name].get_icon(scale, used_mods, image_cache);
+        if self.item_with_label.contains_key(id) {
+            return self.item_with_label[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.item_with_inventory.contains_key(name) {
-            return self.item_with_inventory[name].get_icon(scale, used_mods, image_cache);
+        if self.item_with_inventory.contains_key(id) {
+            return self.item_with_inventory[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.blueprint_book.contains_key(name) {
-            return self.blueprint_book[name].get_icon(scale, used_mods, image_cache);
+        if self.blueprint_book.contains_key(id) {
+            return self.blueprint_book[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.item_with_tags.contains_key(name) {
-            return self.item_with_tags[name].get_icon(scale, used_mods, image_cache);
+        if self.item_with_tags.contains_key(id) {
+            return self.item_with_tags[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.selection_tool.contains_key(name) {
-            return self.selection_tool[name].get_icon(scale, used_mods, image_cache);
+        if self.selection_tool.contains_key(id) {
+            return self.selection_tool[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.blueprint.contains_key(name) {
-            return self.blueprint[name].get_icon(scale, used_mods, image_cache);
+        if self.blueprint.contains_key(id) {
+            return self.blueprint[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.copy_paste_tool.contains_key(name) {
-            return self.copy_paste_tool[name].get_icon(scale, used_mods, image_cache);
+        if self.copy_paste_tool.contains_key(id) {
+            return self.copy_paste_tool[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.deconstruction_item.contains_key(name) {
-            return self.deconstruction_item[name].get_icon(scale, used_mods, image_cache);
+        if self.deconstruction_item.contains_key(id) {
+            return self.deconstruction_item[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.upgrade_item.contains_key(name) {
-            return self.upgrade_item[name].get_icon(scale, used_mods, image_cache);
+        if self.upgrade_item.contains_key(id) {
+            return self.upgrade_item[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.module.contains_key(name) {
-            return self.module[name].get_icon(scale, used_mods, image_cache);
+        if self.module.contains_key(id) {
+            return self.module[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.rail_planner.contains_key(name) {
-            return self.rail_planner[name].get_icon(scale, used_mods, image_cache);
+        if self.rail_planner.contains_key(id) {
+            return self.rail_planner[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.spidertron_remote.contains_key(name) {
-            return self.spidertron_remote[name].get_icon(scale, used_mods, image_cache);
+        if self.spidertron_remote.contains_key(id) {
+            return self.spidertron_remote[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.tool.contains_key(name) {
-            return self.tool[name].get_icon(scale, used_mods, image_cache);
+        if self.tool.contains_key(id) {
+            return self.tool[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.armor.contains_key(name) {
-            return self.armor[name].get_icon(scale, used_mods, image_cache);
+        if self.armor.contains_key(id) {
+            return self.armor[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.mining_tool.contains_key(name) {
-            return self.mining_tool[name].get_icon(scale, used_mods, image_cache);
+        if self.mining_tool.contains_key(id) {
+            return self.mining_tool[id].get_icon(scale, used_mods, image_cache);
         }
 
-        if self.repair_tool.contains_key(name) {
-            return self.repair_tool[name].get_icon(scale, used_mods, image_cache);
+        if self.repair_tool.contains_key(id) {
+            return self.repair_tool[id].get_icon(scale, used_mods, image_cache);
         }
 
         None
@@ -395,11 +550,11 @@ mod test {
                     icon_mipmaps: 0,
                 },
                 dark_background_icon: None,
-                place_result: String::new(),
+                place_result: EntityID::new(""),
                 place_as_tile: None,
-                placed_as_equipment_result: String::new(),
-                fuel_category: String::new(),
-                burnt_result: String::new(),
+                placed_as_equipment_result: EquipmentID::new(""),
+                fuel_category: FuelCategoryID::new(""),
+                burnt_result: ItemID::new(""),
                 pictures: None,
                 flags: FactorioArray::default(),
                 default_request_amount: None,

--- a/prototypes/src/item/item_with_label.rs
+++ b/prototypes/src/item/item_with_label.rs
@@ -10,6 +10,20 @@ use types::{
     Color, FactorioArray, FilterMode, ItemGroupID, ItemID, ItemStackIndex, ItemSubGroupID,
 };
 
+// ItemWithTags = ItemWithLabel
+// using newtype pattern to avoid type collisions
+/// [`Prototypes/ItemWithTagsPrototype`](https://lua-api.factorio.com/latest/prototypes/ItemWithTagsPrototype.html)
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ItemWithTagsPrototype(ItemWithLabelPrototype);
+
+impl std::ops::Deref for ItemWithTagsPrototype {
+    type Target = ItemWithLabelPrototype;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// [`Prototypes/ItemWithLabelPrototype`](https://lua-api.factorio.com/latest/prototypes/ItemWithLabelPrototype.html)
 pub type ItemWithLabelPrototype = crate::BasePrototype<ItemWithLabelPrototypeData>;
 
@@ -130,6 +144,3 @@ impl std::ops::Deref for BlueprintBookPrototypeData {
         &self.parent
     }
 }
-
-/// [`Prototypes/ItemWithTagsPrototype`](https://lua-api.factorio.com/latest/prototypes/ItemWithTagsPrototype.html)
-pub type ItemWithTagsPrototype = ItemWithLabelPrototype;

--- a/prototypes/src/item/item_with_label/selection_tool.rs
+++ b/prototypes/src/item/item_with_label/selection_tool.rs
@@ -113,7 +113,7 @@ impl std::ops::Deref for SelectionToolPrototypeData {
 
 #[must_use]
 fn default_mouse_cursor() -> MouseCursorID {
-    "selection-tool-cursor".to_owned()
+    MouseCursorID::new("selection-tool-cursor")
 }
 
 #[must_use]
@@ -121,8 +121,19 @@ fn is_default_mouse_cursor(mouse_cursor: &MouseCursorID) -> bool {
     *mouse_cursor == default_mouse_cursor()
 }
 
-// [`Prototypes/BlueprintItemPrototype`](https://lua-api.factorio.com/latest/prototypes/BlueprintItemPrototype.html)
-pub type BlueprintItemPrototype = SelectionToolPrototype;
+// BlueprintItem = SelectionTool
+// using newtype pattern to avoid type collisions
+/// [`Prototypes/BlueprintItemPrototype`](https://lua-api.factorio.com/latest/prototypes/BlueprintItemPrototype.html)
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BlueprintItemPrototype(SelectionToolPrototype);
+
+impl std::ops::Deref for BlueprintItemPrototype {
+    type Target = SelectionToolPrototype;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Prototypes/CopyPasteToolPrototype`](https://lua-api.factorio.com/latest/prototypes/CopyPasteToolPrototype.html)
 pub type CopyPasteToolPrototype = crate::BasePrototype<CopyPasteToolPrototypeData>;

--- a/prototypes/src/item/tool.rs
+++ b/prototypes/src/item/tool.rs
@@ -59,9 +59,20 @@ impl std::ops::Deref for ArmorPrototypeData {
     }
 }
 
+// MiningTool = Tool
+// using newtype pattern to avoid type collisions
 /// [`Prototypes/MiningToolPrototype`](https://lua-api.factorio.com/latest/prototypes/MiningToolPrototype.html)
 /// _deprecated_
-pub type MiningToolPrototype = ToolPrototype;
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MiningToolPrototype(ToolPrototype);
+
+impl std::ops::Deref for MiningToolPrototype {
+    type Target = ToolPrototype;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Prototypes/RepairToolPrototype`](https://lua-api.factorio.com/latest/prototypes/RepairToolPrototype.html)
 pub type RepairToolPrototype = crate::BasePrototype<RepairToolPrototypeData>;

--- a/prototypes/src/signal.rs
+++ b/prototypes/src/signal.rs
@@ -29,10 +29,10 @@ impl SignalPrototypeData {
     }
 }
 
-fn default_subgroup() -> String {
-    "virtual-signal".to_string()
+fn default_subgroup() -> ItemSubGroupID {
+    ItemSubGroupID::new("virtual-signal")
 }
 
-fn is_default_subgroup(subgroup: &String) -> bool {
+fn is_default_subgroup(subgroup: &ItemSubGroupID) -> bool {
     *subgroup == default_subgroup()
 }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "types"
-version = "2.1.0-1.1.107"
+version = "2.2.0-1.1.107"
 authors.workspace = true
 edition.workspace = true
 

--- a/types/src/item.rs
+++ b/types/src/item.rs
@@ -5,13 +5,58 @@ use serde_helper as helper;
 use crate::FactorioArray;
 
 /// [`Types/ItemID`](https://lua-api.factorio.com/latest/types/ItemID.html)
-pub type ItemID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct ItemID(String);
+
+impl ItemID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for ItemID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/ItemGroupID`](https://lua-api.factorio.com/latest/types/ItemGroupID.html)
-pub type ItemGroupID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct ItemGroupID(String);
+
+impl ItemGroupID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for ItemGroupID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/ItemSubGroupID`](https://lua-api.factorio.com/latest/types/ItemSubGroupID.html)
-pub type ItemSubGroupID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct ItemSubGroupID(String);
+
+impl ItemSubGroupID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for ItemSubGroupID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/ItemStackIndex`](https://lua-api.factorio.com/latest/types/ItemStackIndex.html)
 pub type ItemStackIndex = u16;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -46,7 +46,22 @@ use tracing::warn;
 pub use wire::*;
 
 /// [`Types/AmmoCategoryID`](https://lua-api.factorio.com/latest/types/AmmoCategoryID.html)
-pub type AmmoCategoryID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct AmmoCategoryID(String);
+
+impl AmmoCategoryID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for AmmoCategoryID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/AmmoType`](https://lua-api.factorio.com/latest/types/AmmoType.html)
 #[skip_serializing_none]
@@ -998,7 +1013,22 @@ impl std::ops::Neg for RealOrientation {
 }
 
 /// [`Types/FuelCategoryID`](https://lua-api.factorio.com/latest/types/FuelCategoryID.html)
-pub type FuelCategoryID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct FuelCategoryID(String);
+
+impl FuelCategoryID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for FuelCategoryID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -1013,13 +1043,58 @@ pub enum FuelCategory {
 }
 
 /// [`Types/TileID`](https://lua-api.factorio.com/latest/types/TileID.html)
-pub type TileID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct TileID(String);
+
+impl TileID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for TileID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/VirtualSignalID`](https://lua-api.factorio.com/latest/types/VirtualSignalID.html)
-pub type VirtualSignalID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct VirtualSignalID(String);
+
+impl VirtualSignalID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for VirtualSignalID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/FluidID`](https://lua-api.factorio.com/latest/types/FluidID.html)
-pub type FluidID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct FluidID(String);
+
+impl FluidID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for FluidID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -1186,19 +1261,94 @@ impl FluidBox {
 }
 
 /// [`Types/RecipeID`](https://lua-api.factorio.com/latest/types/RecipeID.html)
-pub type RecipeID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct RecipeID(String);
+
+impl RecipeID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for RecipeID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/RecipeCategoryID`](https://lua-api.factorio.com/latest/types/RecipeCategoryID.html)
-pub type RecipeCategoryID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct RecipeCategoryID(String);
+
+impl RecipeCategoryID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for RecipeCategoryID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/EquipmentGridID`](https://lua-api.factorio.com/latest/types/EquipmentGridID.html)
-pub type EquipmentGridID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct EquipmentGridID(String);
+
+impl EquipmentGridID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for EquipmentGridID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/EquipmentID`](https://lua-api.factorio.com/latest/types/EquipmentID.html)
-pub type EquipmentID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct EquipmentID(String);
+
+impl EquipmentID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for EquipmentID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/ResourceCategoryID`](https://lua-api.factorio.com/latest/types/ResourceCategoryID.html)
-pub type ResourceCategoryID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct ResourceCategoryID(String);
+
+impl ResourceCategoryID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for ResourceCategoryID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -1261,7 +1411,22 @@ pub enum CursorBoxType {
 }
 
 /// [`Types/MouseCursorID`](https://lua-api.factorio.com/latest/types/MouseCursorID.html)
-pub type MouseCursorID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct MouseCursorID(String);
+
+impl MouseCursorID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for MouseCursorID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// [`Types/ItemToPlace`](https://lua-api.factorio.com/latest/types/ItemToPlace.html)
 #[derive(Debug, Serialize, Deserialize)]
@@ -1283,7 +1448,22 @@ pub enum PlaceableBy {
 pub type CollisionMask = FactorioArray<String>;
 
 /// [`Types/EntityID`](https://lua-api.factorio.com/latest/types/EntityID.html)
-pub type EntityID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct EntityID(String);
+
+impl EntityID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for EntityID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Union used in [`Types/EntityPrototypeFlags`](https://lua-api.factorio.com/latest/types/EntityPrototypeFlags.html)
 #[derive(Debug, Serialize, Deserialize)]
@@ -1842,7 +2022,22 @@ impl TryFrom<u8> for Direction {
 }
 
 /// [`Types/DamageTypeID`](https://lua-api.factorio.com/latest/types/DamageTypeID.html)
-pub type DamageTypeID = String;
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct DamageTypeID(String);
+
+impl DamageTypeID {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+}
+
+impl std::ops::Deref for DamageTypeID {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 /// Single element of [`Types/Resistances`](https://lua-api.factorio.com/latest/types/Resistances.html)
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
- added methods to get retrieve prototype data
- added checks to make sure 2 walls should connect based on their [`visual_merge_group`](https://lua-api.factorio.com/latest/prototypes/WallPrototype.html#visual_merge_group)