### PR TITLE
perf: skip wire rendering if there are over 10000

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ types = { path = "types" }
 unsafe_code = "warn"
 
 [workspace.lints.clippy]
-nursery = "warn"
-pedantic = "warn"
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 unwrap_used = "warn"
 expect_used = "warn"
 

--- a/prototypes/src/lib.rs
+++ b/prototypes/src/lib.rs
@@ -1334,6 +1334,14 @@ impl RenderLayerBuffer {
         image_cache: &mut types::ImageCache,
     ) {
         let dd = self.generate_wire_draw_data(wire_data);
+        let count = dd.iter().map(std::vec::Vec::len).sum::<usize>();
+
+        if count > 10_000 {
+            tracing::warn!("too many wires to draw ({count})");
+            return;
+        }
+
+        tracing::info!("drawing wires");
 
         let target_size = self.target_size.clone();
         let layer = self.get_layer(InternalRenderLayer::Wire);


### PR DESCRIPTION
bandaid solution to blueprints with loads of wires causing huge slowdowns